### PR TITLE
Implement remove, reverse & fromVarArray in StableBuffer

### DIFF
--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -17,6 +17,7 @@
 /// determined at construction and cannot be changed).
 
 import Prim "mo:⛔";
+import Nat "mo:base/Nat";
 
 module {
 
@@ -71,6 +72,25 @@ module {
     } else {
       buffer.count -= 1;
       ?buffer.elems[buffer.count]
+    };
+  };
+
+  /// Removes the item at `index` from the buffer and returns it or `null` if 
+  /// `index >= size`.
+  /// All elements with index > `index` are shifted one position to the left.
+  /// Note: `index` is zero-based.
+  public func remove<X>(buffer: StableBuffer<X>, index : Nat) : ?X {
+    if (index >= buffer.count) {
+      null
+    } else {
+      let element = ?buffer.elems[index];
+      var idx = index;
+      while (idx < (buffer.count - 1 : Nat)) {
+        buffer.elems[idx] := buffer.elems[idx + 1];
+        idx += 1;
+      };
+      buffer.count -= 1;
+      element
     };
   };
 

--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -127,6 +127,16 @@ module {
     ys
   };
 
+  /// Creates a Buffer from the elements of a mutable Array.
+  public func fromVarArray<X>(xs: [var X]): StableBuffer<X> {
+    let ys: StableBuffer<X> = initPresized(xs.size());
+    for (x in xs.vals()) {
+      add(ys, x);
+    };
+
+    ys
+  };
+
   /// Creates a new array containing this buffer's elements.
   public func toArray<X>(buffer: StableBuffer<X>) : [X] =
     // immutable clone of array
@@ -170,4 +180,23 @@ module {
   public func put<X>(buffer: StableBuffer<X>, i : Nat, elem : X) {
     buffer.elems[i] := elem;
   };
+
+  /// Reverses the order of elements in `buffer`.
+  public func reverse<X>(buffer: StableBuffer<X>) {
+    let sz = size(buffer);
+    if (sz == 0) {
+      return
+    };
+
+    var i = 0;
+    var j = sz - 1 : Nat;
+    var temp = get(buffer, 0);
+    while (i < sz / 2) {
+      temp := get(buffer, j);
+      put(buffer, j, get(buffer, i));
+      put(buffer, i, temp);
+      i += 1;
+      j -= 1
+    }
+  }
 }

--- a/test/StableBufferTest.mo
+++ b/test/StableBufferTest.mo
@@ -101,6 +101,14 @@ do {
   assert (B.size<Nat>(d) == arr.size()); 
 };
 
+// test fromVarArray
+do {
+  let arr = [var 1,2,3,4,5];
+  let d = B.fromVarArray<Nat>(arr);
+  assert (natIterEq(B.vals<Nat>(d), arr.vals())); 
+  assert (B.size<Nat>(d) == arr.size()); 
+};
+
 // test init
 do {
   let e = B.init<Nat>();
@@ -114,4 +122,16 @@ do {
   assert (B.toArray(e).size() == 3);
   assert (B.toVarArray(e).size() == 3);
   assert (e.elems.size() == 4);
-}
+};
+
+// test reverse
+do {
+  let e = B.init<Nat>();
+  B.add(e, 0);
+  B.add(e, 1);
+  B.add(e, 2);
+  B.add(e, 3);
+  B.reverse(e);
+  let expected = [3, 2, 1, 0];
+  assert (natIterEq(B.vals<Nat>(e), expected.vals())); 
+};

--- a/test/StableBufferTest.mo
+++ b/test/StableBufferTest.mo
@@ -93,6 +93,18 @@ do {
   assert (B.toVarArray(c).size() == 2);
 };
 
+// test remove
+do {
+  let arr = [1,2,3,4,5,6,7,8,9,10];
+  let d = B.fromArray<Nat>(arr);
+  assert(B.remove(d, 1) == ?2);
+  assert(B.remove(d, 4) == ?6);
+  assert(B.remove(d, 0) == ?1);
+  assert(B.remove(d, 6) == ?10);
+  let expected = [3, 4, 5, 7, 8, 9];
+  assert (natIterEq(B.vals<Nat>(d), expected.vals())); 
+};
+
 // test fromArray
 do {
   let arr = [1,2,3,4,5];

--- a/test/StableBufferTest.mo
+++ b/test/StableBufferTest.mo
@@ -97,12 +97,21 @@ do {
 do {
   let arr = [1,2,3,4,5,6,7,8,9,10];
   let d = B.fromArray<Nat>(arr);
-  assert(B.remove(d, 1) == ?2);
-  assert(B.remove(d, 4) == ?6);
-  assert(B.remove(d, 0) == ?1);
-  assert(B.remove(d, 6) == ?10);
+  assert(B.remove(d, 1) == 2);
+  assert(B.remove(d, 4) == 6);
+  assert(B.remove(d, 0) == 1);
+  assert(B.remove(d, 6) == 10);
   let expected = [3, 4, 5, 7, 8, 9];
-  assert (natIterEq(B.vals<Nat>(d), expected.vals())); 
+  assert (natIterEq(B.vals<Nat>(d), expected.vals()));
+  
+  // remove 4 more elements to trigger downsizing.
+  assert(B.remove(d, 1) == 4);
+  assert(B.remove(d, 0) == 3);
+  assert(B.remove(d, 2) == 8);
+  assert(B.remove(d, 1) == 7);
+
+  let expectedAfterDownsize = [5, 9];
+  assert (natIterEq(B.vals<Nat>(d), expectedAfterDownsize.vals()));
 };
 
 // test fromArray


### PR DESCRIPTION
Per [this forum discussion](https://forum.dfinity.org/t/open-icdevs-org-bounty-46-candy-library-documentation-and-refactoring-2-000/17963/5?u=darkdrag00n), it would be nice to port over a few more utilities functions from Base library to  StableBuffer

Implemented the following functions:
- [x] `reverse`
- [x] `fromVarArray` 
- [x]  `remove`