### PR TITLE
Update to base/Buffer 0.8.7 part 2

### DIFF
--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -746,7 +746,7 @@ module {
         if (i < buffer.count) {
           buffer.elems[i + size2] := buffer.elems[i];
         };
-        buffer.elems[i] := getOpt(buffer2, (i - index));
+        buffer.elems[i] := getOpt(buffer2, (i - index : Nat));
 
         i += 1;
       };


### PR DESCRIPTION
This is the 2nd part to port new functions from base/Buffer.

- :one: <- functions already added in #11 
- [x] <- functions added in this PR
- [ ]  <- functions that will be added in further PRs

# Buffer functions

- :one: initPresized
- :one: init
- :one: size
- :one: add
- :one: get
- :one: getOpt
- :one: put
- :one: removeLast
- :one: remove
- :one: clear
- [x] filterEntries
- :one: capacity
- :one: reserve
- :one: append
- [x] insert
- [x] insertBuffer
- [x] sort
- :one: vals
- [x] isEmpty
- :one: contains
- :one: clone
- [x] max
- [x] min
- [x] equal
- [x] compare
- [x] toText
- [x] hash
- :one: indexOf
- [ ] lastIndexOf
- [ ] indexOfBuffer
- [ ] binarySearch
- [ ] subBuffer
- [ ] isSubBufferOf
- [ ] isStrictSubBufferOf
- [ ] prefix
- [ ] isPrefixOf
- [ ] isStrictPrefixOf
- [ ] suffix
- [ ] isSuffixOf
- [ ] isStrictSuffixOf
- [ ] forAll
- [ ] forSome
- [ ] forNone
- :one: toArray
- :one: toVarArray
- :one: fromArray
- [ ] fromVarArray
- [ ] fromIter
- [ ] trimToSize
- [ ] map
- [ ] iterate
- [ ] mapEntries
- [ ] mapFilter
- [ ] mapResult
- [ ] chain
- [ ] foldLeft
- [ ] foldRight
- [ ] first
- [ ] last
- [ ] make
- [ ] reverse
- [ ] merge
- [ ] removeDuplicates
- [ ] partition
- [ ] split
- [ ] chunk
- [ ] groupBy
- [ ] flatten
- [ ] zip
- [ ] zipWith
- [ ] takeWhile
- [ ] dropWhile
