### PR TITLE
Update tests to base 0.8.7 part2

### DIFF
--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/dfinity/vessel-package-set/releases/download/mo-0.6.21-20220215/package-set.dhall sha256:b46f30e811fe5085741be01e126629c2a55d4c3d6ebf49408fb3b4a98e37589b  
+      https://github.com/dfinity/vessel-package-set/releases/download/mo-0.9.1-20230516/package-set.dhall sha256:1ec31bbdea0234767f35941608d4c763b9dd9951858158057fa92a4a71b574d6
 
 in  upstream

--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -746,7 +746,7 @@ module {
         if (i < buffer.count) {
           buffer.elems[i + size2] := buffer.elems[i];
         };
-        buffer.elems[i] := getOpt(buffer2, (i - index));
+        buffer.elems[i] := getOpt(buffer2, (i - index : Nat));
 
         i += 1;
       };

--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -2053,7 +2053,7 @@ module {
   /// Runtime: O(1)
   ///
   /// Space: O(1)
-  public func last<X>(buffer : StableBuffer<X>) : X = get(buffer, size(buffer) - 1);
+  public func last<X>(buffer : StableBuffer<X>) : X = get(buffer, size(buffer) - 1 : Nat);
 
   /// Returns a new buffer with capacity and size 1, containing `element`.
   ///

--- a/test/Buffer.test.mo
+++ b/test/Buffer.test.mo
@@ -1,0 +1,3741 @@
+import Prim "mo:⛔";
+import B "mo:base/Buffer";
+import Iter "mo:base/Iter";
+import Option "mo:base/Option";
+import Nat "mo:base/Nat";
+import Hash "mo:base/Hash";
+import Nat32 "mo:base/Nat32";
+import Order "mo:base/Order";
+
+import Suite "mo:matchers/Suite";
+import T "mo:matchers/Testable";
+import M "mo:matchers/Matchers";
+
+let { run; test; suite } = Suite;
+
+let NatBufferTestable : T.Testable<B.Buffer<Nat>> = object {
+  public func display(buffer : B.Buffer<Nat>) : Text {
+    B.toText(buffer, Nat.toText)
+  };
+  public func equals(buffer1 : B.Buffer<Nat>, buffer2 : B.Buffer<Nat>) : Bool {
+    B.equal(buffer1, buffer2, Nat.equal)
+  }
+};
+
+class OrderTestable(initItem : Order.Order) : T.TestableItem<Order.Order> {
+  public let item = initItem;
+  public func display(order : Order.Order) : Text {
+    switch (order) {
+      case (#less) {
+        "#less"
+      };
+      case (#greater) {
+        "#greater"
+      };
+      case (#equal) {
+        "#equal"
+      }
+    }
+  };
+  public let equals = Order.equal
+};
+
+/* --------------------------------------- */
+run(
+  suite(
+    "construct",
+    [
+      test(
+        "initial size",
+        B.Buffer<Nat>(10).size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "initial capacity",
+        B.Buffer<Nat>(10).capacity(),
+        M.equals(T.nat(10))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+var buffer = B.Buffer<Nat>(10);
+for (i in Iter.range(0, 3)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "add",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(4))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(10))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(2);
+for (i in Iter.range(0, 3)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "add with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(4))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(0);
+for (i in Iter.range(0, 3)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "add with capacity change, initial capacity 0",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(4))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(2);
+
+run(
+  suite(
+    "removeLast on empty buffer",
+    [
+      test(
+        "return value",
+        buffer.removeLast(),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(2);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "removeLast",
+    [
+      test(
+        "return value",
+        buffer.removeLast(),
+        M.equals(T.optional<Nat>(T.natTestable, ?5))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+for (i in Iter.range(0, 5)) {
+  ignore buffer.removeLast()
+};
+
+run(
+  suite(
+    "removeLast until empty",
+    [
+      test(
+        "return value",
+        buffer.removeLast(),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(0);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "remove",
+    [
+      test(
+        "return value",
+        buffer.remove(2),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 3, 4, 5]))
+      ),
+      test(
+        "return value",
+        buffer.remove(0),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(4))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [1, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+for (i in Iter.range(0, 2)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "remove last element at capacity",
+    [
+      test(
+        "return value",
+        buffer.remove(2),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(0);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+for (i in Iter.range(0, 5)) {
+  ignore buffer.remove(5 - i)
+};
+
+run(
+  suite(
+    "remove until empty",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(1);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.filterEntries(func(_, x) = x % 2 == 0);
+
+run(
+  suite(
+    "filterEntries",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(1);
+buffer.filterEntries(func(_, x) = x % 2 == 0);
+
+run(
+  suite(
+    "filterEntries on empty",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(12);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+buffer.filterEntries(func(i, x) = i + x == 2);
+
+run(
+  suite(
+    "filterEntries size down",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [1]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(5);
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+buffer.filterEntries(func(_, _) = false);
+
+run(
+  suite(
+    "filterEntries size down to empty",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "get and getOpt",
+    [
+      test(
+        "get",
+        buffer.get(2),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "getOpt success",
+        buffer.getOpt(0),
+        M.equals(T.optional(T.natTestable, ?0))
+      ),
+      test(
+        "getOpt out of bounds",
+        buffer.getOpt(10),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.put(2, 20);
+
+run(
+  suite(
+    "put",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 20, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.reserve(6);
+
+run(
+  suite(
+    "decrease capacity",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.reserve(20);
+
+run(
+  suite(
+    "increase capacity",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(20))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+var buffer2 = B.Buffer<Nat>(20);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.append(buffer2);
+
+run(
+  suite(
+    "append",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(18))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(0);
+
+buffer.append(buffer2);
+
+run(
+  suite(
+    "append empty buffer",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(10))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(10);
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(0, 5)) {
+  buffer2.add(i)
+};
+
+buffer.append(buffer2);
+
+run(
+  suite(
+    "append to empty buffer",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(10))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.insert(3, 30);
+
+run(
+  suite(
+    "insert",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.insert(6, 60);
+
+run(
+  suite(
+    "insert at back",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 60]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.insert(0, 10);
+
+run(
+  suite(
+    "insert at front",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [10, 0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(6);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer.insert(3, 30);
+
+run(
+  suite(
+    "insert with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(9))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(5);
+
+buffer.insert(0, 0);
+
+run(
+  suite(
+    "insert into empty buffer",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(0);
+
+buffer.insert(0, 0);
+
+run(
+  suite(
+    "insert into empty buffer with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(15);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(3, buffer2);
+
+run(
+  suite(
+    "insertBuffer",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(15))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(15);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(0, buffer2);
+
+run(
+  suite(
+    "insertBuffer at start",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(15))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(15);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(6, buffer2);
+
+run(
+  suite(
+    "insertBuffer at end",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(15))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(3, buffer2);
+
+run(
+  suite(
+    "insertBuffer with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(18))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(0, buffer2);
+
+run(
+  suite(
+    "insertBuffer at start with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(18))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(8);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(6, buffer2);
+
+run(
+  suite(
+    "insertBuffer at end with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(12))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(18))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(7);
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(0, buffer2);
+
+run(
+  suite(
+    "insertBuffer to empty buffer",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+buffer2 := B.Buffer<Nat>(10);
+
+for (i in Iter.range(10, 15)) {
+  buffer2.add(i)
+};
+
+buffer.insertBuffer(0, buffer2);
+
+run(
+  suite(
+    "insertBuffer to empty buffer with capacity change",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(9))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer.clear();
+
+run(
+  suite(
+    "clear",
+    [
+      test(
+        "size",
+        buffer.size(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer2 := B.clone(buffer);
+
+run(
+  suite(
+    "clone",
+    [
+      test(
+        "size",
+        buffer2.size(),
+        M.equals(T.nat(buffer.size()))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(buffer2.capacity()))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer2)))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+var size = 0;
+
+for (element in buffer.vals()) {
+  M.assertThat(element, M.equals(T.nat(size)));
+  size += 1
+};
+
+run(
+  suite(
+    "vals",
+    [
+      test(
+        "size",
+        size,
+        M.equals(T.nat(7))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+run(
+  suite(
+    "array round trips",
+    [
+      test(
+        "fromArray and toArray",
+        B.toArray<Nat>(B.fromArray<Nat>([0, 1, 2, 3])),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+      ),
+      test(
+        "fromVarArray",
+        B.toArray<Nat>(B.fromVarArray<Nat>([var 0, 1, 2, 3])),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+run(
+  suite(
+    "empty array round trips",
+    [
+      test(
+        "fromArray and toArray",
+        B.toArray<Nat>(B.fromArray<Nat>([])),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      ),
+      test(
+        "fromVarArray",
+        B.toArray<Nat>(B.fromVarArray<Nat>([var])),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "iter round trips",
+    [
+      test(
+        "fromIter and vals",
+        B.toArray(B.fromIter<Nat>(buffer.vals())),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
+      ),
+      test(
+        "empty",
+        B.toArray(B.fromIter<Nat>(B.Buffer<Nat>(2).vals())),
+        M.equals(T.array<Nat>(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+B.trimToSize(buffer);
+
+run(
+  suite(
+    "trimToSize",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(7))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+B.trimToSize(buffer);
+
+run(
+  suite(
+    "trimToSize on empty",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer2 := B.map<Nat, Nat>(buffer, func x = x * 2);
+
+run(
+  suite(
+    "map",
+    [
+      test(
+        "capacity",
+        buffer2.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer2),
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6, 8, 10, 12]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(0);
+
+buffer2 := B.map<Nat, Nat>(buffer, func x = x * 2);
+
+run(
+  suite(
+    "map empty",
+    [
+      test(
+        "capacity",
+        buffer2.capacity(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer2),
+        M.equals(T.array<Nat>(T.natTestable, []))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+var sum = 0;
+
+B.iterate<Nat>(buffer, func x = sum += x);
+
+run(
+  suite(
+    "iterate",
+    [
+      test(
+        "sum",
+        sum,
+        M.equals(T.nat(21))
+      ),
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer2 := B.chain<Nat, Nat>(buffer, func x = B.make<Nat> x);
+
+run(
+  suite(
+    "chain",
+    [
+      test(
+        "elements",
+        B.toArray(buffer2),
+        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer)))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer2 := B.mapFilter<Nat, Nat>(buffer, func x = if (x % 2 == 0) { ?x } else { null });
+
+run(
+  suite(
+    "mapFilter",
+    [
+      test(
+        "capacity",
+        buffer2.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer2),
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+buffer2 := B.mapEntries<Nat, Nat>(buffer, func(i, x) = i * x);
+
+run(
+  suite(
+    "mapEntries",
+    [
+      test(
+        "capacity",
+        buffer2.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer2),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 4, 9, 16, 25, 36]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+var bufferResult = B.mapResult<Nat, Nat, Text>(buffer, func x = #ok x);
+
+run(
+  suite(
+    "mapResult success",
+    [
+      test(
+        "return value",
+        #ok buffer,
+        M.equals(T.result<B.Buffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+bufferResult := B.mapResult<Nat, Nat, Text>(
+  buffer,
+  func x = if (x == 4) { #err "error" } else { #ok x }
+);
+
+run(
+  suite(
+    "mapResult failure",
+    [
+      test(
+        "return value",
+        #err "error",
+        M.equals(T.result<B.Buffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "foldLeft",
+    [
+      test(
+        "return value",
+        B.foldLeft<Text, Nat>(buffer, "", func(acc, x) = acc # Nat.toText(x)),
+        M.equals(T.text("0123456"))
+      ),
+      test(
+        "return value empty",
+        B.foldLeft<Text, Nat>(B.Buffer<Nat>(4), "", func(acc, x) = acc # Nat.toText(x)),
+        M.equals(T.text(""))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "foldRight",
+    [
+      test(
+        "return value",
+        B.foldRight<Nat, Text>(buffer, "", func(x, acc) = acc # Nat.toText(x)),
+        M.equals(T.text("6543210"))
+      ),
+      test(
+        "return value empty",
+        B.foldRight<Nat, Text>(B.Buffer<Nat>(4), "", func(x, acc) = acc # Nat.toText(x)),
+        M.equals(T.text(""))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "forAll",
+    [
+      test(
+        "true",
+        B.forAll<Nat>(buffer, func x = x >= 0),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "false",
+        B.forAll<Nat>(buffer, func x = x % 2 == 0),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "default",
+        B.forAll<Nat>(B.Buffer<Nat>(2), func _ = false),
+        M.equals(T.bool(true))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+run(
+  suite(
+    "forSome",
+    [
+      test(
+        "true",
+        B.forSome<Nat>(buffer, func x = x % 2 == 0),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "false",
+        B.forSome<Nat>(buffer, func x = x < 0),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "default",
+        B.forSome<Nat>(B.Buffer<Nat>(2), func _ = false),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+run(
+  suite(
+    "forNone",
+    [
+      test(
+        "true",
+        B.forNone<Nat>(buffer, func x = x < 0),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "false",
+        B.forNone<Nat>(buffer, func x = x % 2 != 0),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "default",
+        B.forNone<Nat>(B.Buffer<Nat>(2), func _ = true),
+        M.equals(T.bool(true))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.make<Nat>(1);
+
+run(
+  suite(
+    "make",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [1]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "contains",
+    [
+      test(
+        "true",
+        B.contains<Nat>(buffer, 2, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "true",
+        B.contains<Nat>(buffer, 9, Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+run(
+  suite(
+    "contains empty",
+    [
+      test(
+        "true",
+        B.contains<Nat>(buffer, 2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "true",
+        B.contains<Nat>(buffer, 9, Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+buffer.add(2);
+buffer.add(1);
+buffer.add(10);
+buffer.add(1);
+buffer.add(0);
+buffer.add(3);
+
+run(
+  suite(
+    "max",
+    [
+      test(
+        "return value",
+        B.max<Nat>(buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, ?10))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+buffer.add(2);
+buffer.add(1);
+buffer.add(10);
+buffer.add(1);
+buffer.add(0);
+buffer.add(3);
+buffer.add(0);
+
+run(
+  suite(
+    "min",
+    [
+      test(
+        "return value",
+        B.min<Nat>(buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, ?0))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+buffer.add(2);
+
+run(
+  suite(
+    "isEmpty",
+    [
+      test(
+        "true",
+        B.isEmpty(B.Buffer<Nat>(2)),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "false",
+        B.isEmpty(buffer),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+buffer.add(2);
+buffer.add(1);
+buffer.add(10);
+buffer.add(1);
+buffer.add(0);
+buffer.add(3);
+buffer.add(0);
+
+B.removeDuplicates<Nat>(buffer, Nat.compare);
+
+run(
+  suite(
+    "removeDuplicates",
+    [
+      test(
+        "elements (stable ordering)",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [2, 1, 10, 0, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+B.removeDuplicates<Nat>(buffer, Nat.compare);
+
+run(
+  suite(
+    "removeDuplicates empty",
+    [
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(2)
+};
+
+B.removeDuplicates<Nat>(buffer, Nat.compare);
+
+run(
+  suite(
+    "removeDuplicates repeat singleton",
+    [
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [2]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "hash",
+    [
+      test(
+        "empty buffer",
+        Nat32.toNat(B.hash<Nat>(B.Buffer<Nat>(8), Hash.hash)),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "non-empty buffer",
+        Nat32.toNat(B.hash<Nat>(buffer, Hash.hash)),
+        M.equals(T.nat(3365238326))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "toText",
+    [
+      test(
+        "empty buffer",
+        B.toText<Nat>(B.Buffer<Nat>(3), Nat.toText),
+        M.equals(T.text("[]"))
+      ),
+      test(
+        "singleton buffer",
+        B.toText<Nat>(B.make<Nat>(3), Nat.toText),
+        M.equals(T.text("[3]"))
+      ),
+      test(
+        "non-empty buffer",
+        B.toText<Nat>(buffer, Nat.toText),
+        M.equals(T.text("[0, 1, 2, 3, 4, 5]"))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 2)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "equal",
+    [
+      test(
+        "empty buffers",
+        B.equal<Nat>(B.Buffer<Nat>(3), B.Buffer<Nat>(2), Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "non-empty buffers",
+        B.equal<Nat>(buffer, B.clone(buffer), Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "non-empty and empty buffers",
+        B.equal<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "non-empty buffers mismatching lengths",
+        B.equal<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer2 := B.Buffer<Nat>(3);
+
+for (i in Iter.range(0, 2)) {
+  buffer.add(i)
+};
+
+var buffer3 = B.Buffer<Nat>(3);
+
+for (i in Iter.range(2, 5)) {
+  buffer3.add(i)
+};
+
+run(
+  suite(
+    "compare",
+    [
+      test(
+        "empty buffers",
+        B.compare<Nat>(B.Buffer<Nat>(3), B.Buffer<Nat>(2), Nat.compare),
+        M.equals(OrderTestable(#equal))
+      ),
+      test(
+        "non-empty buffers equal",
+        B.compare<Nat>(buffer, B.clone(buffer), Nat.compare),
+        M.equals(OrderTestable(#equal))
+      ),
+      test(
+        "non-empty and empty buffers",
+        B.compare<Nat>(buffer, B.Buffer<Nat>(3), Nat.compare),
+        M.equals(OrderTestable(#greater))
+      ),
+      test(
+        "non-empty buffers mismatching lengths",
+        B.compare<Nat>(buffer, buffer2, Nat.compare),
+        M.equals(OrderTestable(#greater))
+      ),
+      test(
+        "non-empty buffers lexicographic difference",
+        B.compare<Nat>(buffer, buffer3, Nat.compare),
+        M.equals(OrderTestable(#less))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+var nestedBuffer = B.Buffer<B.Buffer<Nat>>(3);
+for (i in Iter.range(0, 4)) {
+  let innerBuffer = B.Buffer<Nat>(2);
+  for (j in if (i % 2 == 0) { Iter.range(0, 4) } else { Iter.range(0, 3) }) {
+    innerBuffer.add(j)
+  };
+  nestedBuffer.add(innerBuffer)
+};
+nestedBuffer.add(B.Buffer<Nat>(2));
+
+buffer := B.flatten<Nat>(nestedBuffer);
+
+run(
+  suite(
+    "flatten",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(45))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+nestedBuffer := B.Buffer<B.Buffer<Nat>>(3);
+for (i in Iter.range(0, 4)) {
+  nestedBuffer.add(B.Buffer<Nat>(2))
+};
+
+buffer := B.flatten<Nat>(nestedBuffer);
+
+run(
+  suite(
+    "flatten all empty inner buffers",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+nestedBuffer := B.Buffer<B.Buffer<Nat>>(3);
+buffer := B.flatten<Nat>(nestedBuffer);
+
+run(
+  suite(
+    "flatten empty outer buffer",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(0))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 7)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+for (i in Iter.range(0, 6)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+var buffer4 = B.make<Nat>(3);
+
+B.reverse<Nat>(buffer);
+B.reverse<Nat>(buffer2);
+B.reverse<Nat>(buffer3);
+B.reverse<Nat>(buffer4);
+
+run(
+  suite(
+    "reverse",
+    [
+      test(
+        "even elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [7, 6, 5, 4, 3, 2, 1, 0]))
+      ),
+      test(
+        "odd elements",
+        B.toArray(buffer2),
+        M.equals(T.array(T.natTestable, [6, 5, 4, 3, 2, 1, 0]))
+      ),
+      test(
+        "empty",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "singleton",
+        B.toArray(buffer4),
+        M.equals(T.array(T.natTestable, [3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer.clear();
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+var partition = B.partition<Nat>(buffer, func x = x % 2 == 0);
+buffer2 := partition.0;
+buffer3 := partition.1;
+
+run(
+  suite(
+    "partition",
+    [
+      test(
+        "capacity of true buffer",
+        buffer2.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements of true buffer",
+        B.toArray(buffer2),
+        M.equals(T.array(T.natTestable, [0, 2, 4]))
+      ),
+      test(
+        "capacity of false buffer",
+        buffer3.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements of false buffer",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [1, 3, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer.clear();
+for (i in Iter.range(0, 3)) {
+  buffer.add(i)
+};
+
+for (i in Iter.range(10, 13)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+for (i in Iter.range(2, 5)) {
+  buffer2.add(i)
+};
+for (i in Iter.range(13, 15)) {
+  buffer2.add(i)
+};
+
+buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
+
+run(
+  suite(
+    "merge",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(23))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 2, 3, 3, 4, 5, 10, 11, 12, 13, 13, 14, 15]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer.clear();
+for (i in Iter.range(0, 3)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
+
+run(
+  suite(
+    "merge with empty",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+
+buffer.clear();
+buffer2.clear();
+
+buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
+
+run(
+  suite(
+    "merge two empty",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.add(0);
+buffer.add(2);
+buffer.add(1);
+buffer.add(1);
+buffer.add(5);
+buffer.add(4);
+
+buffer.sort(Nat.compare);
+
+run(
+  suite(
+    "sort even",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.add(0);
+buffer.add(2);
+buffer.add(1);
+buffer.add(1);
+buffer.add(5);
+
+buffer.sort(Nat.compare);
+
+run(
+  suite(
+    "sort odd",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.sort(Nat.compare);
+
+run(
+  suite(
+    "sort empty",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer.add(2);
+
+buffer.sort(Nat.compare);
+
+run(
+  suite(
+    "sort singleton",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [2] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+partition := B.split<Nat>(buffer, 2);
+buffer2 := partition.0;
+buffer3 := partition.1;
+
+run(
+  suite(
+    "split",
+    [
+      test(
+        "capacity prefix",
+        buffer2.capacity(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "elements prefix",
+        B.toArray(buffer2),
+        M.equals(T.array(T.natTestable, [0, 1]))
+      ),
+      test(
+        "capacity suffix",
+        buffer3.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements suffix",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+partition := B.split<Nat>(buffer, 0);
+buffer2 := partition.0;
+buffer3 := partition.1;
+
+run(
+  suite(
+    "split at index 0",
+    [
+      test(
+        "capacity prefix",
+        buffer2.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements prefix",
+        B.toArray(buffer2),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "capacity suffix",
+        buffer3.capacity(),
+        M.equals(T.nat(9))
+      ),
+      test(
+        "elements suffix",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+partition := B.split<Nat>(buffer, 6);
+buffer2 := partition.0;
+buffer3 := partition.1;
+
+run(
+  suite(
+    "split at last index",
+    [
+      test(
+        "capacity prefix",
+        buffer2.capacity(),
+        M.equals(T.nat(9))
+      ),
+      test(
+        "elements prefix",
+        B.toArray(buffer2),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5]))
+      ),
+      test(
+        "capacity suffix",
+        buffer3.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements suffix",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer2.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+for (i in Iter.range(0, 3)) {
+  buffer2.add(i)
+};
+
+var bufferPairs = B.zip<Nat, Nat>(buffer, buffer2);
+
+run(
+  suite(
+    "zip",
+    [
+      test(
+        "capacity",
+        bufferPairs.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(bufferPairs),
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [(0, 0), (1, 1), (2, 2), (3, 3)]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer2.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+bufferPairs := B.zip<Nat, Nat>(buffer, buffer2);
+
+run(
+  suite(
+    "zip empty",
+    [
+      test(
+        "capacity",
+        bufferPairs.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(bufferPairs),
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer2.clear();
+
+bufferPairs := B.zip<Nat, Nat>(buffer, buffer2);
+
+run(
+  suite(
+    "zip both empty",
+    [
+      test(
+        "capacity",
+        bufferPairs.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(bufferPairs),
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer2.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+for (i in Iter.range(0, 3)) {
+  buffer2.add(i)
+};
+
+buffer3 := B.zipWith<Nat, Nat, Nat>(buffer, buffer2, Nat.add);
+
+run(
+  suite(
+    "zipWith",
+    [
+      test(
+        "capacity",
+        buffer3.capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [0, 2, 4, 6]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+buffer2.clear();
+
+for (i in Iter.range(0, 5)) {
+  buffer.add(i)
+};
+
+buffer3 := B.zipWith<Nat, Nat, Nat>(buffer, buffer2, Nat.add);
+
+run(
+  suite(
+    "zipWithEmpty",
+    [
+      test(
+        "capacity",
+        buffer3.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer3),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 8)) {
+  buffer.add(i)
+};
+
+var chunks = B.chunk<Nat>(buffer, 2);
+
+run(
+  suite(
+    "chunk",
+    [
+      test(
+        "num chunks",
+        chunks.size(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "chunk 0 capacity",
+        chunks.get(0).capacity(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "chunk 0 elements",
+        B.toArray(chunks.get(0)),
+        M.equals(T.array(T.natTestable, [0, 1]))
+      ),
+      test(
+        "chunk 2 capacity",
+        chunks.get(2).capacity(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "chunk 2 elements",
+        B.toArray(chunks.get(2)),
+        M.equals(T.array(T.natTestable, [4, 5]))
+      ),
+      test(
+        "chunk 4 capacity",
+        chunks.get(4).capacity(),
+        M.equals(T.nat(3))
+      ),
+      test(
+        "chunk 4 elements",
+        B.toArray(chunks.get(4)),
+        M.equals(T.array(T.natTestable, [8]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+chunks := B.chunk<Nat>(buffer, 3);
+
+run(
+  suite(
+    "chunk empty",
+    [
+      test(
+        "num chunks",
+        chunks.size(),
+        M.equals(T.nat(0))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+chunks := B.chunk<Nat>(buffer, 10);
+
+run(
+  suite(
+    "chunk larger than buffer",
+    [
+      test(
+        "num chunks",
+        chunks.size(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "chunk 0 elements",
+        B.toArray(chunks.get(0)),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.add(2);
+buffer.add(2);
+buffer.add(2);
+buffer.add(1);
+buffer.add(0);
+buffer.add(0);
+buffer.add(2);
+buffer.add(1);
+buffer.add(1);
+
+var groups = B.groupBy<Nat>(buffer, Nat.equal);
+
+run(
+  suite(
+    "groupBy",
+    [
+      test(
+        "num groups",
+        groups.size(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "group 0 capacity",
+        groups.get(0).capacity(),
+        M.equals(T.nat(9))
+      ),
+      test(
+        "group 0 elements",
+        B.toArray(groups.get(0)),
+        M.equals(T.array(T.natTestable, [2, 2, 2]))
+      ),
+      test(
+        "group 1 capacity",
+        groups.get(1).capacity(),
+        M.equals(T.nat(6))
+      ),
+      test(
+        "group 1 elements",
+        B.toArray(groups.get(1)),
+        M.equals(T.array(T.natTestable, [1]))
+      ),
+      test(
+        "group 4 capacity",
+        groups.get(4).capacity(),
+        M.equals(T.nat(2))
+      ),
+      test(
+        "group 4 elements",
+        B.toArray(groups.get(4)),
+        M.equals(T.array(T.natTestable, [1, 1]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+groups := B.groupBy<Nat>(buffer, Nat.equal);
+
+run(
+  suite(
+    "groupBy clear",
+    [
+      test(
+        "num groups",
+        groups.size(),
+        M.equals(T.nat(0))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(0)
+};
+
+groups := B.groupBy<Nat>(buffer, Nat.equal);
+
+run(
+  suite(
+    "groupBy clear",
+    [
+      test(
+        "num groups",
+        groups.size(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "group 0 elements",
+        B.toArray(groups.get(0)),
+        M.equals(T.array(T.natTestable, [0, 0, 0, 0, 0]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer := B.prefix<Nat>(buffer, 3);
+
+run(
+  suite(
+    "prefix",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 2]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer := B.prefix<Nat>(buffer, 0);
+
+run(
+  suite(
+    "prefix of empty",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(1))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer := B.prefix<Nat>(buffer, 5);
+
+run(
+  suite(
+    "trivial prefix",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(8))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+for (i in Iter.range(0, 2)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+buffer3.add(2);
+buffer3.add(1);
+buffer3.add(0);
+
+run(
+  suite(
+    "isPrefixOf",
+    [
+      test(
+        "normal prefix",
+        B.isPrefixOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "identical buffers",
+        B.isPrefixOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "one empty buffer",
+        B.isPrefixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not prefix",
+        B.isPrefixOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not prefix from length",
+        B.isPrefixOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not prefix of empty",
+        B.isPrefixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty prefix of empty",
+        B.isPrefixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(true))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+for (i in Iter.range(0, 2)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+buffer3.add(2);
+buffer3.add(1);
+buffer3.add(0);
+
+run(
+  suite(
+    "isStrictPrefixOf",
+    [
+      test(
+        "normal prefix",
+        B.isStrictPrefixOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "identical buffers",
+        B.isStrictPrefixOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "one empty buffer",
+        B.isStrictPrefixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not prefix",
+        B.isStrictPrefixOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not prefix from length",
+        B.isStrictPrefixOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not prefix of empty",
+        B.isStrictPrefixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty prefix of empty",
+        B.isStrictPrefixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer := B.subBuffer<Nat>(buffer, 1, 3);
+
+run(
+  suite(
+    "subBuffer",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [1, 2, 3]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "subBuffer edge cases",
+    [
+      test(
+        "prefix",
+        B.prefix(buffer, 3),
+        M.equals({ { item = B.subBuffer(buffer, 0, 3) } and NatBufferTestable })
+      ),
+      test(
+        "suffix",
+        B.suffix(buffer, 3),
+        M.equals({ { item = B.subBuffer(buffer, 2, 3) } and NatBufferTestable })
+      ),
+      test(
+        "empty",
+        B.toArray(B.subBuffer(buffer, 2, 0)),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "trivial",
+        B.subBuffer(buffer, 0, buffer.size()),
+        M.equals({ { item = buffer } and NatBufferTestable })
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+for (i in Iter.range(0, 2)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+for (i in Iter.range(1, 3)) {
+  buffer3.add(i)
+};
+
+run(
+  suite(
+    "isSubBufferOf",
+    [
+      test(
+        "normal subBuffer",
+        B.isSubBufferOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "prefix",
+        B.isSubBufferOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "identical buffers",
+        B.isSubBufferOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "one empty buffer",
+        B.isSubBufferOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not subBuffer",
+        B.isSubBufferOf<Nat>(buffer3, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not subBuffer from length",
+        B.isSubBufferOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not subBuffer of empty",
+        B.isSubBufferOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty subBuffer of empty",
+        B.isSubBufferOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(true))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+
+for (i in Iter.range(0, 2)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+for (i in Iter.range(1, 3)) {
+  buffer3.add(i)
+};
+
+buffer4 := B.Buffer<Nat>(4);
+
+for (i in Iter.range(3, 4)) {
+  buffer4.add(i)
+};
+
+run(
+  suite(
+    "isStrictSubBufferOf",
+    [
+      test(
+        "normal strict subBuffer",
+        B.isStrictSubBufferOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "prefix",
+        B.isStrictSubBufferOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "suffix",
+        B.isStrictSubBufferOf<Nat>(buffer4, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "identical buffers",
+        B.isStrictSubBufferOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "one empty buffer",
+        B.isStrictSubBufferOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not subBuffer",
+        B.isStrictSubBufferOf<Nat>(buffer3, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not subBuffer from length",
+        B.isStrictSubBufferOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not subBuffer of empty",
+        B.isStrictSubBufferOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty not strict subBuffer of empty",
+        B.isStrictSubBufferOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer := B.suffix<Nat>(buffer, 3);
+
+run(
+  suite(
+    "suffix",
+    [
+      test(
+        "capacity",
+        buffer.capacity(),
+        M.equals(T.nat(5))
+      ),
+      test(
+        "elements",
+        B.toArray(buffer),
+        M.equals(T.array(T.natTestable, [2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "suffix edge cases",
+    [
+      test(
+        "empty",
+        B.toArray(B.prefix(buffer, 0)),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "trivial",
+        B.prefix(buffer, buffer.size()),
+        M.equals({ { item = buffer } and NatBufferTestable })
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+for (i in Iter.range(3, 4)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+buffer3.add(2);
+buffer3.add(1);
+buffer3.add(0);
+
+run(
+  suite(
+    "isSuffixOf",
+    [
+      test(
+        "normal suffix",
+        B.isSuffixOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "identical buffers",
+        B.isSuffixOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "one empty buffer",
+        B.isSuffixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not suffix",
+        B.isSuffixOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not suffix from length",
+        B.isSuffixOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not suffix of empty",
+        B.isSuffixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty suffix of empty",
+        B.isSuffixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(true))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+buffer2.clear();
+for (i in Iter.range(3, 4)) {
+  buffer2.add(i)
+};
+
+buffer3.clear();
+
+buffer3.add(2);
+buffer3.add(1);
+buffer3.add(0);
+
+run(
+  suite(
+    "isStrictSuffixOf",
+    [
+      test(
+        "normal suffix",
+        B.isStrictSuffixOf<Nat>(buffer2, buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "identical buffers",
+        B.isStrictSuffixOf<Nat>(buffer, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "one empty buffer",
+        B.isStrictSuffixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true))
+      ),
+      test(
+        "not suffix",
+        B.isStrictSuffixOf<Nat>(buffer3, buffer, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not suffix from length",
+        B.isStrictSuffixOf<Nat>(buffer, buffer2, Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "not suffix of empty",
+        B.isStrictSuffixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      ),
+      test(
+        "empty suffix of empty",
+        B.isStrictSuffixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.bool(false))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "takeWhile",
+    [
+      test(
+        "normal case",
+        B.toArray(B.takeWhile<Nat>(buffer, func x = x < 3)),
+        M.equals(T.array(T.natTestable, [0, 1, 2]))
+      ),
+      test(
+        "empty",
+        B.toArray(B.takeWhile<Nat>(B.Buffer<Nat>(3), func x = x < 3)),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 4)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "dropWhile",
+    [
+      test(
+        "normal case",
+        B.toArray(B.dropWhile<Nat>(buffer, func x = x < 3)),
+        M.equals(T.array(T.natTestable, [3, 4]))
+      ),
+      test(
+        "empty",
+        B.toArray(B.dropWhile<Nat>(B.Buffer<Nat>(3), func x = x < 3)),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "drop all",
+        B.toArray(B.dropWhile<Nat>(buffer, func _ = true)),
+        M.equals(T.array(T.natTestable, [] : [Nat]))
+      ),
+      test(
+        "drop none",
+        B.toArray(B.dropWhile<Nat>(buffer, func _ = false)),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(1, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "binarySearch",
+    [
+      test(
+        "find in middle",
+        B.binarySearch<Nat>(2, buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, ?1))
+      ),
+      test(
+        "find first",
+        B.binarySearch<Nat>(1, buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, ?0))
+      ),
+      test(
+        "find last",
+        B.binarySearch<Nat>(6, buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, ?5))
+      ),
+      test(
+        "not found to the right",
+        B.binarySearch<Nat>(10, buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "not found to the left",
+        B.binarySearch<Nat>(0, buffer, Nat.compare),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+for (i in Iter.range(0, 6)) {
+  buffer.add(i)
+};
+
+run(
+  suite(
+    "indexOf",
+    [
+      test(
+        "find in middle",
+        B.indexOf<Nat>(2, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?2))
+      ),
+      test(
+        "find first",
+        B.indexOf<Nat>(0, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?0))
+      ),
+      test(
+        "find last",
+        B.indexOf<Nat>(6, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?6))
+      ),
+      test(
+        "not found",
+        B.indexOf<Nat>(10, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "empty",
+        B.indexOf<Nat>(100, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.add(2); // 0
+buffer.add(2); // 1
+buffer.add(1); // 2
+buffer.add(10); // 3
+buffer.add(1); // 4
+buffer.add(0); // 5
+buffer.add(10); // 6
+buffer.add(3); // 7
+buffer.add(0); // 8
+
+run(
+  suite(
+    "lastIndexOf",
+    [
+      test(
+        "find in middle",
+        B.lastIndexOf<Nat>(10, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?6))
+      ),
+      test(
+        "find only",
+        B.lastIndexOf<Nat>(3, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?7))
+      ),
+      test(
+        "find last",
+        B.lastIndexOf<Nat>(0, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?8))
+      ),
+      test(
+        "not found",
+        B.lastIndexOf<Nat>(100, buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "empty",
+        B.lastIndexOf<Nat>(100, B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      )
+    ]
+  )
+);
+
+/* --------------------------------------- */
+buffer.clear();
+
+buffer.add(2); // 0
+buffer.add(2); // 1
+buffer.add(1); // 2
+buffer.add(10); // 3
+buffer.add(1); // 4
+buffer.add(10); // 5
+buffer.add(3); // 6
+buffer.add(0); // 7
+
+run(
+  suite(
+    "indexOfBuffer",
+    [
+      test(
+        "find in middle",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([1, 10, 1]), buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?2))
+      ),
+      test(
+        "find first",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([2, 2, 1, 10]), buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?0))
+      ),
+      test(
+        "find last",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([0]), buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, ?7))
+      ),
+      test(
+        "not found",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([99, 100, 1]), buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "search for empty buffer",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([]), buffer, Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "search through empty buffer",
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([1, 2, 3]), B.Buffer<Nat>(2), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      ),
+      test(
+        "search for empty in empty",
+        B.indexOfBuffer<Nat>(B.Buffer<Nat>(2), B.Buffer<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat))
+      )
+    ]
+  )
+)

--- a/test/Buffer.test.mo
+++ b/test/Buffer.test.mo
@@ -1,5 +1,5 @@
 import Prim "mo:⛔";
-import B "mo:base/Buffer";
+import B "../src/StableBuffer";
 import Iter "mo:base/Iter";
 import Option "mo:base/Option";
 import Nat "mo:base/Nat";
@@ -13,13 +13,13 @@ import M "mo:matchers/Matchers";
 
 let { run; test; suite } = Suite;
 
-let NatBufferTestable : T.Testable<B.Buffer<Nat>> = object {
-  public func display(buffer : B.Buffer<Nat>) : Text {
-    B.toText(buffer, Nat.toText)
+let NatBufferTestable : T.Testable<B.StableBuffer<Nat>> = object {
+  public func display(buffer : B.StableBuffer<Nat>) : Text {
+    B.toText(buffer, Nat.toText);
   };
-  public func equals(buffer1 : B.Buffer<Nat>, buffer2 : B.Buffer<Nat>) : Bool {
-    B.equal(buffer1, buffer2, Nat.equal)
-  }
+  public func equals(buffer1 : B.StableBuffer<Nat>, buffer2 : B.StableBuffer<Nat>) : Bool {
+    B.equal(buffer1, buffer2, Nat.equal);
+  };
 };
 
 class OrderTestable(initItem : Order.Order) : T.TestableItem<Order.Order> {
@@ -27,17 +27,17 @@ class OrderTestable(initItem : Order.Order) : T.TestableItem<Order.Order> {
   public func display(order : Order.Order) : Text {
     switch (order) {
       case (#less) {
-        "#less"
+        "#less";
       };
       case (#greater) {
-        "#greater"
+        "#greater";
       };
       case (#equal) {
-        "#equal"
-      }
-    }
+        "#equal";
+      };
+    };
   };
-  public let equals = Order.equal
+  public let equals = Order.equal;
 };
 
 /* --------------------------------------- */
@@ -47,23 +47,23 @@ run(
     [
       test(
         "initial size",
-        B.Buffer<Nat>(10).size(),
-        M.equals(T.nat(0))
+        B.size(B.initPresized<Nat>(10)),
+        M.equals(T.nat(0)),
       ),
       test(
         "initial capacity",
-        B.Buffer<Nat>(10).capacity(),
-        M.equals(T.nat(10))
-      )
-    ]
+        B.capacity(B.initPresized<Nat>(10)),
+        M.equals(T.nat(10)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-var buffer = B.Buffer<Nat>(10);
+var buffer = B.initPresized<Nat>(10);
 for (i in Iter.range(0, 3)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -72,27 +72,27 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(4))
+        B.size(buffer),
+        M.equals(T.nat(4)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(10))
+        B.capacity(buffer),
+        M.equals(T.nat(10)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(2);
+buffer := B.initPresized<Nat>(2);
 for (i in Iter.range(0, 3)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -101,27 +101,27 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(4))
+        B.size(buffer),
+        M.equals(T.nat(4)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(0);
+buffer := B.initPresized<Nat>(0);
 for (i in Iter.range(0, 3)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -130,25 +130,25 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(4))
+        B.size(buffer),
+        M.equals(T.nat(4)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(2);
+buffer := B.initPresized<Nat>(2);
 
 run(
   suite(
@@ -156,32 +156,32 @@ run(
     [
       test(
         "return value",
-        buffer.removeLast(),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        B.removeLast(buffer),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(2))
+        B.capacity(buffer),
+        M.equals(T.nat(2)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(2);
+buffer := B.initPresized<Nat>(2);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -190,36 +190,36 @@ run(
     [
       test(
         "return value",
-        buffer.removeLast(),
-        M.equals(T.optional<Nat>(T.natTestable, ?5))
+        B.removeLast(buffer),
+        M.equals(T.optional<Nat>(T.natTestable, ?5)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(5))
+        B.size(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 for (i in Iter.range(0, 5)) {
-  ignore buffer.removeLast()
+  ignore B.removeLast(buffer);
 };
 
 run(
@@ -228,32 +228,32 @@ run(
     [
       test(
         "return value",
-        buffer.removeLast(),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        B.removeLast(buffer),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(2))
+        B.capacity(buffer),
+        M.equals(T.nat(2)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(0);
+buffer := B.initPresized<Nat>(0);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -262,52 +262,52 @@ run(
     [
       test(
         "return value",
-        buffer.remove(2),
-        M.equals(T.nat(2))
+        B.remove(buffer, 2),
+        M.equals(T.nat(2)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(5))
+        B.size(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 3, 4, 5]))
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 3, 4, 5])),
       ),
       test(
         "return value",
-        buffer.remove(0),
-        M.equals(T.nat(0))
+        B.remove(buffer, 0),
+        M.equals(T.nat(0)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(4))
+        B.size(buffer),
+        M.equals(T.nat(4)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [1, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [1, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 for (i in Iter.range(0, 2)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -316,36 +316,36 @@ run(
     [
       test(
         "return value",
-        buffer.remove(2),
-        M.equals(T.nat(2))
+        B.remove(buffer, 2),
+        M.equals(T.nat(2)),
       ),
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(2))
+        B.size(buffer),
+        M.equals(T.nat(2)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(3))
+        B.capacity(buffer),
+        M.equals(T.nat(3)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(0);
+buffer := B.initPresized<Nat>(0);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 for (i in Iter.range(0, 5)) {
-  ignore buffer.remove(5 - i)
+  ignore B.remove(buffer, 5 - i : Nat);
 };
 
 run(
@@ -354,30 +354,30 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(2))
+        B.capacity(buffer),
+        M.equals(T.nat(2)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(1);
+buffer := B.initPresized<Nat>(1);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.filterEntries(func(_, x) = x % 2 == 0);
+B.filterEntries<Nat>(buffer, func(_, x) = x % 2 == 0);
 
 run(
   suite(
@@ -385,26 +385,26 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(3))
+        B.size(buffer),
+        M.equals(T.nat(3)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(1);
-buffer.filterEntries(func(_, x) = x % 2 == 0);
+buffer := B.initPresized<Nat>(1);
+B.filterEntries<Nat>(buffer, func(_, x) = x % 2 == 0);
 
 run(
   suite(
@@ -412,29 +412,29 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(12);
+buffer := B.initPresized<Nat>(12);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
-buffer.filterEntries(func(i, x) = i + x == 2);
+B.filterEntries<Nat>(buffer, func(i, x) = i + x == 2);
 
 run(
   suite(
@@ -442,29 +442,29 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(1))
+        B.size(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [1]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [1])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(5);
+buffer := B.initPresized<Nat>(5);
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
-buffer.filterEntries(func(_, _) = false);
+B.filterEntries<Nat>(buffer, func(_, _) = false);
 
 run(
   suite(
@@ -472,27 +472,27 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(2))
+        B.capacity(buffer),
+        M.equals(T.nat(2)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -501,30 +501,30 @@ run(
     [
       test(
         "get",
-        buffer.get(2),
-        M.equals(T.nat(2))
+        B.get(buffer, 2),
+        M.equals(T.nat(2)),
       ),
       test(
         "getOpt success",
-        buffer.getOpt(0),
-        M.equals(T.optional(T.natTestable, ?0))
+        B.getOpt(buffer, 0),
+        M.equals(T.optional(T.natTestable, ?0)),
       ),
       test(
         "getOpt out of bounds",
-        buffer.getOpt(10),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      )
-    ]
+        B.getOpt(buffer, 10),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.put(2, 20);
+B.put(buffer, 2, 20);
 
 run(
   suite(
@@ -532,25 +532,25 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 20, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 20, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.reserve(6);
+B.reserve(buffer, 6);
 
 run(
   suite(
@@ -558,30 +558,30 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.reserve(20);
+B.reserve(buffer, 20);
 
 run(
   suite(
@@ -589,36 +589,36 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(20))
+        B.capacity(buffer),
+        M.equals(T.nat(20)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-var buffer2 = B.Buffer<Nat>(20);
+var buffer2 = B.initPresized<Nat>(20);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.append(buffer2);
+B.append(buffer, buffer2);
 
 run(
   suite(
@@ -626,32 +626,32 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(18))
+        B.capacity(buffer),
+        M.equals(T.nat(18)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(0);
+buffer2 := B.initPresized<Nat>(0);
 
-buffer.append(buffer2);
+B.append(buffer, buffer2);
 
 run(
   suite(
@@ -659,33 +659,33 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(10))
+        B.capacity(buffer),
+        M.equals(T.nat(10)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(10);
+buffer := B.initPresized<Nat>(10);
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(0, 5)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.append(buffer2);
+B.append(buffer, buffer2);
 
 run(
   suite(
@@ -693,31 +693,31 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(10))
+        B.capacity(buffer),
+        M.equals(T.nat(10)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.insert(3, 30);
+B.insert(buffer, 3, 30);
 
 run(
   suite(
@@ -725,31 +725,31 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(7))
+        B.size(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.insert(6, 60);
+B.insert(buffer, 6, 60);
 
 run(
   suite(
@@ -757,31 +757,31 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(7))
+        B.size(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 60]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 60])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.insert(0, 10);
+B.insert(buffer, 0, 10);
 
 run(
   suite(
@@ -789,31 +789,31 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(7))
+        B.size(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [10, 0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [10, 0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(6);
+buffer := B.initPresized<Nat>(6);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.insert(3, 30);
+B.insert(buffer, 3, 30);
 
 run(
   suite(
@@ -821,27 +821,27 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(7))
+        B.size(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(9))
+        B.capacity(buffer),
+        M.equals(T.nat(9)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 30, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(5);
+buffer := B.initPresized<Nat>(5);
 
-buffer.insert(0, 0);
+B.insert(buffer, 0, 0);
 
 run(
   suite(
@@ -849,27 +849,27 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(1))
+        B.size(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(0);
+buffer := B.initPresized<Nat>(0);
 
-buffer.insert(0, 0);
+B.insert(buffer, 0, 0);
 
 run(
   suite(
@@ -877,37 +877,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(1))
+        B.size(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(15);
+buffer := B.initPresized<Nat>(15);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(3, buffer2);
+B.insertBuffer(buffer, 3, buffer2);
 
 run(
   suite(
@@ -915,37 +915,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(15))
+        B.capacity(buffer),
+        M.equals(T.nat(15)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(15);
+buffer := B.initPresized<Nat>(15);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(0, buffer2);
+B.insertBuffer(buffer, 0, buffer2);
 
 run(
   suite(
@@ -953,37 +953,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(15))
+        B.capacity(buffer),
+        M.equals(T.nat(15)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(15);
+buffer := B.initPresized<Nat>(15);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(6, buffer2);
+B.insertBuffer(buffer, 6, buffer2);
 
 run(
   suite(
@@ -991,37 +991,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(15))
+        B.capacity(buffer),
+        M.equals(T.nat(15)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(3, buffer2);
+B.insertBuffer(buffer, 3, buffer2);
 
 run(
   suite(
@@ -1029,37 +1029,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(18))
+        B.capacity(buffer),
+        M.equals(T.nat(18)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 10, 11, 12, 13, 14, 15, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(0, buffer2);
+B.insertBuffer(buffer, 0, buffer2);
 
 run(
   suite(
@@ -1067,37 +1067,37 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(18))
+        B.capacity(buffer),
+        M.equals(T.nat(18)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(8);
+buffer := B.initPresized<Nat>(8);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(6, buffer2);
+B.insertBuffer(buffer, 6, buffer2);
 
 run(
   suite(
@@ -1105,33 +1105,33 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(12))
+        B.size(buffer),
+        M.equals(T.nat(12)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(18))
+        B.capacity(buffer),
+        M.equals(T.nat(18)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(7);
+buffer := B.initPresized<Nat>(7);
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(0, buffer2);
+B.insertBuffer(buffer, 0, buffer2);
 
 run(
   suite(
@@ -1139,33 +1139,33 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(7))
+        B.capacity(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
-buffer2 := B.Buffer<Nat>(10);
+buffer2 := B.initPresized<Nat>(10);
 
 for (i in Iter.range(10, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer.insertBuffer(0, buffer2);
+B.insertBuffer(buffer, 0, buffer2);
 
 run(
   suite(
@@ -1173,31 +1173,31 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(6))
+        B.size(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(9))
+        B.capacity(buffer),
+        M.equals(T.nat(9)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [10, 11, 12, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer.clear();
+B.clear(buffer);
 
 run(
   suite(
@@ -1205,28 +1205,28 @@ run(
     [
       test(
         "size",
-        buffer.size(),
-        M.equals(T.nat(0))
+        B.size(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer2 := B.clone(buffer);
@@ -1237,35 +1237,35 @@ run(
     [
       test(
         "size",
-        buffer2.size(),
-        M.equals(T.nat(buffer.size()))
+        B.size(buffer2),
+        M.equals(T.nat(B.size(buffer))),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(buffer2.capacity()))
+        B.capacity(buffer),
+        M.equals(T.nat(B.capacity(buffer2))),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer2)))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer2))),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 var size = 0;
 
-for (element in buffer.vals()) {
+for (element in B.vals(buffer)) {
   M.assertThat(element, M.equals(T.nat(size)));
-  size += 1
+  size += 1;
 };
 
 run(
@@ -1275,9 +1275,9 @@ run(
       test(
         "size",
         size,
-        M.equals(T.nat(7))
+        M.equals(T.nat(7)),
       )
-    ]
+    ],
   )
 );
 
@@ -1289,14 +1289,14 @@ run(
       test(
         "fromArray and toArray",
         B.toArray<Nat>(B.fromArray<Nat>([0, 1, 2, 3])),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3])),
       ),
       test(
         "fromVarArray",
         B.toArray<Nat>(B.fromVarArray<Nat>([var 0, 1, 2, 3])),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3])),
+      ),
+    ],
   )
 );
 
@@ -1308,22 +1308,22 @@ run(
       test(
         "fromArray and toArray",
         B.toArray<Nat>(B.fromArray<Nat>([])),
-        M.equals(T.array<Nat>(T.natTestable, []))
+        M.equals(T.array<Nat>(T.natTestable, [])),
       ),
       test(
         "fromVarArray",
         B.toArray<Nat>(B.fromVarArray<Nat>([var])),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1332,23 +1332,23 @@ run(
     [
       test(
         "fromIter and vals",
-        B.toArray(B.fromIter<Nat>(buffer.vals())),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
+        B.toArray(B.fromIter<Nat>(B.vals(buffer))),
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6])),
       ),
       test(
         "empty",
-        B.toArray(B.fromIter<Nat>(B.Buffer<Nat>(2).vals())),
-        M.equals(T.array<Nat>(T.natTestable, [] : [Nat]))
-      )
-    ]
+        B.toArray(B.fromIter<Nat>(B.vals(B.initPresized<Nat>(2)))),
+        M.equals(T.array<Nat>(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 B.trimToSize(buffer);
@@ -1359,20 +1359,20 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(7))
+        B.capacity(buffer),
+        M.equals(T.nat(7)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 B.trimToSize(buffer);
 
@@ -1382,23 +1382,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(0))
+        B.capacity(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer2 := B.map<Nat, Nat>(buffer, func x = x * 2);
@@ -1409,20 +1409,20 @@ run(
     [
       test(
         "capacity",
-        buffer2.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer2),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer2),
-        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6, 8, 10, 12]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6, 8, 10, 12])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(0);
+buffer := B.initPresized<Nat>(0);
 
 buffer2 := B.map<Nat, Nat>(buffer, func x = x * 2);
 
@@ -1432,23 +1432,23 @@ run(
     [
       test(
         "capacity",
-        buffer2.capacity(),
-        M.equals(T.nat(0))
+        B.capacity(buffer2),
+        M.equals(T.nat(0)),
       ),
       test(
         "elements",
         B.toArray(buffer2),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 var sum = 0;
@@ -1462,27 +1462,27 @@ run(
       test(
         "sum",
         sum,
-        M.equals(T.nat(21))
+        M.equals(T.nat(21)),
       ),
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 2, 3, 4, 5, 6])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer2 := B.chain<Nat, Nat>(buffer, func x = B.make<Nat> x);
@@ -1494,17 +1494,17 @@ run(
       test(
         "elements",
         B.toArray(buffer2),
-        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer)))
+        M.equals(T.array<Nat>(T.natTestable, B.toArray(buffer))),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer2 := B.mapFilter<Nat, Nat>(buffer, func x = if (x % 2 == 0) { ?x } else { null });
@@ -1515,23 +1515,23 @@ run(
     [
       test(
         "capacity",
-        buffer2.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer2),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer2),
-        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 2, 4, 6])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer2 := B.mapEntries<Nat, Nat>(buffer, func(i, x) = i * x);
@@ -1542,23 +1542,23 @@ run(
     [
       test(
         "capacity",
-        buffer2.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer2),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer2),
-        M.equals(T.array<Nat>(T.natTestable, [0, 1, 4, 9, 16, 25, 36]))
-      )
-    ]
+        M.equals(T.array<Nat>(T.natTestable, [0, 1, 4, 9, 16, 25, 36])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 var bufferResult = B.mapResult<Nat, Nat, Text>(buffer, func x = #ok x);
@@ -1570,22 +1570,22 @@ run(
       test(
         "return value",
         #ok buffer,
-        M.equals(T.result<B.Buffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult))
+        M.equals(T.result<B.StableBuffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 bufferResult := B.mapResult<Nat, Nat, Text>(
   buffer,
-  func x = if (x == 4) { #err "error" } else { #ok x }
+  func x = if (x == 4) { #err "error" } else { #ok x },
 );
 
 run(
@@ -1595,17 +1595,17 @@ run(
       test(
         "return value",
         #err "error",
-        M.equals(T.result<B.Buffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult))
+        M.equals(T.result<B.StableBuffer<Nat>, Text>(NatBufferTestable, T.textTestable, bufferResult)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1615,22 +1615,22 @@ run(
       test(
         "return value",
         B.foldLeft<Text, Nat>(buffer, "", func(acc, x) = acc # Nat.toText(x)),
-        M.equals(T.text("0123456"))
+        M.equals(T.text("0123456")),
       ),
       test(
         "return value empty",
-        B.foldLeft<Text, Nat>(B.Buffer<Nat>(4), "", func(acc, x) = acc # Nat.toText(x)),
-        M.equals(T.text(""))
-      )
-    ]
+        B.foldLeft<Text, Nat>(B.initPresized<Nat>(4), "", func(acc, x) = acc # Nat.toText(x)),
+        M.equals(T.text("")),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1640,22 +1640,22 @@ run(
       test(
         "return value",
         B.foldRight<Nat, Text>(buffer, "", func(x, acc) = acc # Nat.toText(x)),
-        M.equals(T.text("6543210"))
+        M.equals(T.text("6543210")),
       ),
       test(
         "return value empty",
-        B.foldRight<Nat, Text>(B.Buffer<Nat>(4), "", func(x, acc) = acc # Nat.toText(x)),
-        M.equals(T.text(""))
-      )
-    ]
+        B.foldRight<Nat, Text>(B.initPresized<Nat>(4), "", func(x, acc) = acc # Nat.toText(x)),
+        M.equals(T.text("")),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1665,19 +1665,19 @@ run(
       test(
         "true",
         B.forAll<Nat>(buffer, func x = x >= 0),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "false",
         B.forAll<Nat>(buffer, func x = x % 2 == 0),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "default",
-        B.forAll<Nat>(B.Buffer<Nat>(2), func _ = false),
-        M.equals(T.bool(true))
-      )
-    ]
+        B.forAll<Nat>(B.initPresized<Nat>(2), func _ = false),
+        M.equals(T.bool(true)),
+      ),
+    ],
   )
 );
 
@@ -1689,19 +1689,19 @@ run(
       test(
         "true",
         B.forSome<Nat>(buffer, func x = x % 2 == 0),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "false",
         B.forSome<Nat>(buffer, func x = x < 0),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "default",
-        B.forSome<Nat>(B.Buffer<Nat>(2), func _ = false),
-        M.equals(T.bool(false))
-      )
-    ]
+        B.forSome<Nat>(B.initPresized<Nat>(2), func _ = false),
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
@@ -1713,19 +1713,19 @@ run(
       test(
         "true",
         B.forNone<Nat>(buffer, func x = x < 0),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "false",
         B.forNone<Nat>(buffer, func x = x % 2 != 0),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "default",
-        B.forNone<Nat>(B.Buffer<Nat>(2), func _ = true),
-        M.equals(T.bool(true))
-      )
-    ]
+        B.forNone<Nat>(B.initPresized<Nat>(2), func _ = true),
+        M.equals(T.bool(true)),
+      ),
+    ],
   )
 );
 
@@ -1739,24 +1739,24 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [1]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [1])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1766,20 +1766,20 @@ run(
       test(
         "true",
         B.contains<Nat>(buffer, 2, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "true",
         B.contains<Nat>(buffer, 9, Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 run(
   suite(
@@ -1788,27 +1788,27 @@ run(
       test(
         "true",
         B.contains<Nat>(buffer, 2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "true",
         B.contains<Nat>(buffer, 9, Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
-buffer.add(2);
-buffer.add(1);
-buffer.add(10);
-buffer.add(1);
-buffer.add(0);
-buffer.add(3);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 10);
+B.add(buffer, 1);
+B.add(buffer, 0);
+B.add(buffer, 3);
 
 run(
   suite(
@@ -1817,23 +1817,23 @@ run(
       test(
         "return value",
         B.max<Nat>(buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, ?10))
+        M.equals(T.optional(T.natTestable, ?10)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
-buffer.add(2);
-buffer.add(1);
-buffer.add(10);
-buffer.add(1);
-buffer.add(0);
-buffer.add(3);
-buffer.add(0);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 10);
+B.add(buffer, 1);
+B.add(buffer, 0);
+B.add(buffer, 3);
+B.add(buffer, 0);
 
 run(
   suite(
@@ -1842,16 +1842,16 @@ run(
       test(
         "return value",
         B.min<Nat>(buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, ?0))
+        M.equals(T.optional(T.natTestable, ?0)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
-buffer.add(2);
+buffer := B.initPresized<Nat>(3);
+B.add(buffer, 2);
 
 run(
   suite(
@@ -1859,29 +1859,29 @@ run(
     [
       test(
         "true",
-        B.isEmpty(B.Buffer<Nat>(2)),
-        M.equals(T.bool(true))
+        B.isEmpty(B.initPresized<Nat>(2)),
+        M.equals(T.bool(true)),
       ),
       test(
         "false",
         B.isEmpty(buffer),
-        M.equals(T.bool(false))
-      )
-    ]
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
-buffer.add(2);
-buffer.add(1);
-buffer.add(10);
-buffer.add(1);
-buffer.add(0);
-buffer.add(3);
-buffer.add(0);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 10);
+B.add(buffer, 1);
+B.add(buffer, 0);
+B.add(buffer, 3);
+B.add(buffer, 0);
 
 B.removeDuplicates<Nat>(buffer, Nat.compare);
 
@@ -1892,15 +1892,15 @@ run(
       test(
         "elements (stable ordering)",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [2, 1, 10, 0, 3]))
+        M.equals(T.array(T.natTestable, [2, 1, 10, 0, 3])),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 B.removeDuplicates<Nat>(buffer, Nat.compare);
 
@@ -1911,18 +1911,18 @@ run(
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(2)
+  B.add(buffer, 2);
 };
 
 B.removeDuplicates<Nat>(buffer, Nat.compare);
@@ -1934,17 +1934,17 @@ run(
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [2]))
+        M.equals(T.array(T.natTestable, [2])),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1953,23 +1953,23 @@ run(
     [
       test(
         "empty buffer",
-        Nat32.toNat(B.hash<Nat>(B.Buffer<Nat>(8), Hash.hash)),
-        M.equals(T.nat(0))
+        Nat32.toNat(B.hash<Nat>(B.initPresized<Nat>(8), Hash.hash)),
+        M.equals(T.nat(0)),
       ),
       test(
         "non-empty buffer",
         Nat32.toNat(B.hash<Nat>(buffer, Hash.hash)),
-        M.equals(T.nat(3365238326))
-      )
-    ]
+        M.equals(T.nat(3365238326)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -1978,34 +1978,34 @@ run(
     [
       test(
         "empty buffer",
-        B.toText<Nat>(B.Buffer<Nat>(3), Nat.toText),
-        M.equals(T.text("[]"))
+        B.toText<Nat>(B.initPresized<Nat>(3), Nat.toText),
+        M.equals(T.text("[]")),
       ),
       test(
         "singleton buffer",
         B.toText<Nat>(B.make<Nat>(3), Nat.toText),
-        M.equals(T.text("[3]"))
+        M.equals(T.text("[3]")),
       ),
       test(
         "non-empty buffer",
         B.toText<Nat>(buffer, Nat.toText),
-        M.equals(T.text("[0, 1, 2, 3, 4, 5]"))
-      )
-    ]
+        M.equals(T.text("[0, 1, 2, 3, 4, 5]")),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(3);
+buffer2 := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 2)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -2014,45 +2014,45 @@ run(
     [
       test(
         "empty buffers",
-        B.equal<Nat>(B.Buffer<Nat>(3), B.Buffer<Nat>(2), Nat.equal),
-        M.equals(T.bool(true))
+        B.equal<Nat>(B.initPresized<Nat>(3), B.initPresized<Nat>(2), Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "non-empty buffers",
         B.equal<Nat>(buffer, B.clone(buffer), Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "non-empty and empty buffers",
-        B.equal<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.equal<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "non-empty buffers mismatching lengths",
         B.equal<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer := B.Buffer<Nat>(3);
+buffer := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2 := B.Buffer<Nat>(3);
+buffer2 := B.initPresized<Nat>(3);
 
 for (i in Iter.range(0, 2)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-var buffer3 = B.Buffer<Nat>(3);
+var buffer3 = B.initPresized<Nat>(3);
 
 for (i in Iter.range(2, 5)) {
-  buffer3.add(i)
+  B.add(buffer3, i);
 };
 
 run(
@@ -2061,44 +2061,44 @@ run(
     [
       test(
         "empty buffers",
-        B.compare<Nat>(B.Buffer<Nat>(3), B.Buffer<Nat>(2), Nat.compare),
-        M.equals(OrderTestable(#equal))
+        B.compare<Nat>(B.initPresized<Nat>(3), B.initPresized<Nat>(2), Nat.compare),
+        M.equals(OrderTestable(#equal)),
       ),
       test(
         "non-empty buffers equal",
         B.compare<Nat>(buffer, B.clone(buffer), Nat.compare),
-        M.equals(OrderTestable(#equal))
+        M.equals(OrderTestable(#equal)),
       ),
       test(
         "non-empty and empty buffers",
-        B.compare<Nat>(buffer, B.Buffer<Nat>(3), Nat.compare),
-        M.equals(OrderTestable(#greater))
+        B.compare<Nat>(buffer, B.initPresized<Nat>(3), Nat.compare),
+        M.equals(OrderTestable(#greater)),
       ),
       test(
         "non-empty buffers mismatching lengths",
         B.compare<Nat>(buffer, buffer2, Nat.compare),
-        M.equals(OrderTestable(#greater))
+        M.equals(OrderTestable(#greater)),
       ),
       test(
         "non-empty buffers lexicographic difference",
         B.compare<Nat>(buffer, buffer3, Nat.compare),
-        M.equals(OrderTestable(#less))
-      )
-    ]
+        M.equals(OrderTestable(#less)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-var nestedBuffer = B.Buffer<B.Buffer<Nat>>(3);
+var nestedBuffer = B.initPresized<B.StableBuffer<Nat>>(3);
 for (i in Iter.range(0, 4)) {
-  let innerBuffer = B.Buffer<Nat>(2);
+  let innerBuffer = B.initPresized<Nat>(2);
   for (j in if (i % 2 == 0) { Iter.range(0, 4) } else { Iter.range(0, 3) }) {
-    innerBuffer.add(j)
+    B.add(innerBuffer, j);
   };
-  nestedBuffer.add(innerBuffer)
+  B.add(nestedBuffer, innerBuffer);
 };
-nestedBuffer.add(B.Buffer<Nat>(2));
+B.add(nestedBuffer, B.initPresized<Nat>(2));
 
 buffer := B.flatten<Nat>(nestedBuffer);
 
@@ -2108,23 +2108,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(45))
+        B.capacity(buffer),
+        M.equals(T.nat(45)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-nestedBuffer := B.Buffer<B.Buffer<Nat>>(3);
+nestedBuffer := B.initPresized<B.StableBuffer<Nat>>(3);
 for (i in Iter.range(0, 4)) {
-  nestedBuffer.add(B.Buffer<Nat>(2))
+  B.add(nestedBuffer, B.initPresized<Nat>(2));
 };
 
 buffer := B.flatten<Nat>(nestedBuffer);
@@ -2135,21 +2135,21 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-nestedBuffer := B.Buffer<B.Buffer<Nat>>(3);
+nestedBuffer := B.initPresized<B.StableBuffer<Nat>>(3);
 buffer := B.flatten<Nat>(nestedBuffer);
 
 run(
@@ -2158,32 +2158,32 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(0))
+        B.capacity(buffer),
+        M.equals(T.nat(0)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 7)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 for (i in Iter.range(0, 6)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
 var buffer4 = B.make<Nat>(3);
 
@@ -2199,32 +2199,32 @@ run(
       test(
         "even elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [7, 6, 5, 4, 3, 2, 1, 0]))
+        M.equals(T.array(T.natTestable, [7, 6, 5, 4, 3, 2, 1, 0])),
       ),
       test(
         "odd elements",
         B.toArray(buffer2),
-        M.equals(T.array(T.natTestable, [6, 5, 4, 3, 2, 1, 0]))
+        M.equals(T.array(T.natTestable, [6, 5, 4, 3, 2, 1, 0])),
       ),
       test(
         "empty",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "singleton",
         B.toArray(buffer4),
-        M.equals(T.array(T.natTestable, [3]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer.clear();
+B.clear(buffer);
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 var partition = B.partition<Nat>(buffer, func x = x % 2 == 0);
@@ -2237,45 +2237,45 @@ run(
     [
       test(
         "capacity of true buffer",
-        buffer2.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer2),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements of true buffer",
         B.toArray(buffer2),
-        M.equals(T.array(T.natTestable, [0, 2, 4]))
+        M.equals(T.array(T.natTestable, [0, 2, 4])),
       ),
       test(
         "capacity of false buffer",
-        buffer3.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer3),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements of false buffer",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [1, 3, 5]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [1, 3, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer.clear();
+B.clear(buffer);
 for (i in Iter.range(0, 3)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 for (i in Iter.range(10, 13)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 for (i in Iter.range(2, 5)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 for (i in Iter.range(13, 15)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
 buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
@@ -2286,26 +2286,26 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(23))
+        B.capacity(buffer),
+        M.equals(T.nat(23)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 2, 3, 3, 4, 5, 10, 11, 12, 13, 13, 14, 15]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 2, 3, 3, 4, 5, 10, 11, 12, 13, 13, 14, 15])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer.clear();
+B.clear(buffer);
 for (i in Iter.range(0, 3)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
 
@@ -2315,22 +2315,22 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
 
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 buffer := B.merge<Nat>(buffer, buffer2, Nat.compare);
 
@@ -2340,29 +2340,29 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.add(0);
-buffer.add(2);
-buffer.add(1);
-buffer.add(1);
-buffer.add(5);
-buffer.add(4);
+B.add(buffer, 0);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 1);
+B.add(buffer, 5);
+B.add(buffer, 4);
 
-buffer.sort(Nat.compare);
+B.sort(buffer, Nat.compare);
 
 run(
   suite(
@@ -2370,28 +2370,28 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 4, 5]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.add(0);
-buffer.add(2);
-buffer.add(1);
-buffer.add(1);
-buffer.add(5);
+B.add(buffer, 0);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 1);
+B.add(buffer, 5);
 
-buffer.sort(Nat.compare);
+B.sort(buffer, Nat.compare);
 
 run(
   suite(
@@ -2399,22 +2399,22 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 5]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 1, 2, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.sort(Nat.compare);
+B.sort(buffer, Nat.compare);
 
 run(
   suite(
@@ -2422,23 +2422,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer.add(2);
+B.clear(buffer);
+B.add(buffer, 2);
 
-buffer.sort(Nat.compare);
+B.sort(buffer, Nat.compare);
 
 run(
   suite(
@@ -2446,23 +2446,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [2] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [2] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 partition := B.split<Nat>(buffer, 2);
@@ -2475,33 +2475,33 @@ run(
     [
       test(
         "capacity prefix",
-        buffer2.capacity(),
-        M.equals(T.nat(3))
+        B.capacity(buffer2),
+        M.equals(T.nat(3)),
       ),
       test(
         "elements prefix",
         B.toArray(buffer2),
-        M.equals(T.array(T.natTestable, [0, 1]))
+        M.equals(T.array(T.natTestable, [0, 1])),
       ),
       test(
         "capacity suffix",
-        buffer3.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer3),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements suffix",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 partition := B.split<Nat>(buffer, 0);
@@ -2514,33 +2514,33 @@ run(
     [
       test(
         "capacity prefix",
-        buffer2.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer2),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements prefix",
         B.toArray(buffer2),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "capacity suffix",
-        buffer3.capacity(),
-        M.equals(T.nat(9))
+        B.capacity(buffer3),
+        M.equals(T.nat(9)),
       ),
       test(
         "elements suffix",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 partition := B.split<Nat>(buffer, 6);
@@ -2553,37 +2553,37 @@ run(
     [
       test(
         "capacity prefix",
-        buffer2.capacity(),
-        M.equals(T.nat(9))
+        B.capacity(buffer2),
+        M.equals(T.nat(9)),
       ),
       test(
         "elements prefix",
         B.toArray(buffer2),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5]))
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4, 5])),
       ),
       test(
         "capacity suffix",
-        buffer3.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer3),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements suffix",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 for (i in Iter.range(0, 3)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
 var bufferPairs = B.zip<Nat, Nat>(buffer, buffer2);
@@ -2594,24 +2594,24 @@ run(
     [
       test(
         "capacity",
-        bufferPairs.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(bufferPairs),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(bufferPairs),
-        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [(0, 0), (1, 1), (2, 2), (3, 3)]))
-      )
-    ]
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [(0, 0), (1, 1), (2, 2), (3, 3)])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 bufferPairs := B.zip<Nat, Nat>(buffer, buffer2);
@@ -2622,21 +2622,21 @@ run(
     [
       test(
         "capacity",
-        bufferPairs.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(bufferPairs),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(bufferPairs),
-        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)]))
-      )
-    ]
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 bufferPairs := B.zip<Nat, Nat>(buffer, buffer2);
 
@@ -2646,27 +2646,27 @@ run(
     [
       test(
         "capacity",
-        bufferPairs.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(bufferPairs),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(bufferPairs),
-        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)]))
-      )
-    ]
+        M.equals(T.array(T.tuple2Testable(T.natTestable, T.natTestable), [] : [(Nat, Nat)])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 for (i in Iter.range(0, 3)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
 buffer3 := B.zipWith<Nat, Nat, Nat>(buffer, buffer2, Nat.add);
@@ -2677,24 +2677,24 @@ run(
     [
       test(
         "capacity",
-        buffer3.capacity(),
-        M.equals(T.nat(6))
+        B.capacity(buffer3),
+        M.equals(T.nat(6)),
       ),
       test(
         "elements",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [0, 2, 4, 6]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 2, 4, 6])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
-buffer2.clear();
+B.clear(buffer);
+B.clear(buffer2);
 
 for (i in Iter.range(0, 5)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer3 := B.zipWith<Nat, Nat, Nat>(buffer, buffer2, Nat.add);
@@ -2705,23 +2705,23 @@ run(
     [
       test(
         "capacity",
-        buffer3.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer3),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer3),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 8)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 var chunks = B.chunk<Nat>(buffer, 2);
@@ -2732,45 +2732,45 @@ run(
     [
       test(
         "num chunks",
-        chunks.size(),
-        M.equals(T.nat(5))
+        B.size(chunks),
+        M.equals(T.nat(5)),
       ),
       test(
         "chunk 0 capacity",
-        chunks.get(0).capacity(),
-        M.equals(T.nat(3))
+        B.capacity(B.get(chunks, 0)),
+        M.equals(T.nat(3)),
       ),
       test(
         "chunk 0 elements",
-        B.toArray(chunks.get(0)),
-        M.equals(T.array(T.natTestable, [0, 1]))
+        B.toArray(B.get(chunks, 0)),
+        M.equals(T.array(T.natTestable, [0, 1])),
       ),
       test(
         "chunk 2 capacity",
-        chunks.get(2).capacity(),
-        M.equals(T.nat(3))
+        B.capacity(B.get(chunks, 2)),
+        M.equals(T.nat(3)),
       ),
       test(
         "chunk 2 elements",
-        B.toArray(chunks.get(2)),
-        M.equals(T.array(T.natTestable, [4, 5]))
+        B.toArray(B.get(chunks, 2)),
+        M.equals(T.array(T.natTestable, [4, 5])),
       ),
       test(
         "chunk 4 capacity",
-        chunks.get(4).capacity(),
-        M.equals(T.nat(3))
+        B.capacity(B.get(chunks, 4)),
+        M.equals(T.nat(3)),
       ),
       test(
         "chunk 4 elements",
-        B.toArray(chunks.get(4)),
-        M.equals(T.array(T.natTestable, [8]))
-      )
-    ]
+        B.toArray(B.get(chunks, 4)),
+        M.equals(T.array(T.natTestable, [8])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 chunks := B.chunk<Nat>(buffer, 3);
 
@@ -2780,18 +2780,18 @@ run(
     [
       test(
         "num chunks",
-        chunks.size(),
-        M.equals(T.nat(0))
+        B.size(chunks),
+        M.equals(T.nat(0)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 chunks := B.chunk<Nat>(buffer, 10);
@@ -2802,30 +2802,30 @@ run(
     [
       test(
         "num chunks",
-        chunks.size(),
-        M.equals(T.nat(1))
+        B.size(chunks),
+        M.equals(T.nat(1)),
       ),
       test(
         "chunk 0 elements",
-        B.toArray(chunks.get(0)),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
-      )
-    ]
+        B.toArray(B.get(chunks, 0)),
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.add(2);
-buffer.add(2);
-buffer.add(2);
-buffer.add(1);
-buffer.add(0);
-buffer.add(0);
-buffer.add(2);
-buffer.add(1);
-buffer.add(1);
+B.add(buffer, 2);
+B.add(buffer, 2);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 0);
+B.add(buffer, 0);
+B.add(buffer, 2);
+B.add(buffer, 1);
+B.add(buffer, 1);
 
 var groups = B.groupBy<Nat>(buffer, Nat.equal);
 
@@ -2835,45 +2835,45 @@ run(
     [
       test(
         "num groups",
-        groups.size(),
-        M.equals(T.nat(5))
+        B.size(groups),
+        M.equals(T.nat(5)),
       ),
       test(
         "group 0 capacity",
-        groups.get(0).capacity(),
-        M.equals(T.nat(9))
+        B.capacity(B.get(groups, 0)),
+        M.equals(T.nat(9)),
       ),
       test(
         "group 0 elements",
-        B.toArray(groups.get(0)),
-        M.equals(T.array(T.natTestable, [2, 2, 2]))
+        B.toArray(B.get(groups, 0)),
+        M.equals(T.array(T.natTestable, [2, 2, 2])),
       ),
       test(
         "group 1 capacity",
-        groups.get(1).capacity(),
-        M.equals(T.nat(6))
+        B.capacity(B.get(groups, 1)),
+        M.equals(T.nat(6)),
       ),
       test(
         "group 1 elements",
-        B.toArray(groups.get(1)),
-        M.equals(T.array(T.natTestable, [1]))
+        B.toArray(B.get(groups, 1)),
+        M.equals(T.array(T.natTestable, [1])),
       ),
       test(
         "group 4 capacity",
-        groups.get(4).capacity(),
-        M.equals(T.nat(2))
+        B.capacity(B.get(groups, 4)),
+        M.equals(T.nat(2)),
       ),
       test(
         "group 4 elements",
-        B.toArray(groups.get(4)),
-        M.equals(T.array(T.natTestable, [1, 1]))
-      )
-    ]
+        B.toArray(B.get(groups, 4)),
+        M.equals(T.array(T.natTestable, [1, 1])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 groups := B.groupBy<Nat>(buffer, Nat.equal);
 
@@ -2883,18 +2883,18 @@ run(
     [
       test(
         "num groups",
-        groups.size(),
-        M.equals(T.nat(0))
+        B.size(groups),
+        M.equals(T.nat(0)),
       )
-    ]
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(0)
+  B.add(buffer, 0);
 };
 
 groups := B.groupBy<Nat>(buffer, Nat.equal);
@@ -2905,23 +2905,23 @@ run(
     [
       test(
         "num groups",
-        groups.size(),
-        M.equals(T.nat(1))
+        B.size(groups),
+        M.equals(T.nat(1)),
       ),
       test(
         "group 0 elements",
-        B.toArray(groups.get(0)),
-        M.equals(T.array(T.natTestable, [0, 0, 0, 0, 0]))
-      )
-    ]
+        B.toArray(B.get(groups, 0)),
+        M.equals(T.array(T.natTestable, [0, 0, 0, 0, 0])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer := B.prefix<Nat>(buffer, 3);
@@ -2932,20 +2932,20 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 2]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 buffer := B.prefix<Nat>(buffer, 0);
 
@@ -2955,23 +2955,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(1))
+        B.capacity(buffer),
+        M.equals(T.nat(1)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer := B.prefix<Nat>(buffer, 5);
@@ -2982,36 +2982,36 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(8))
+        B.capacity(buffer),
+        M.equals(T.nat(8)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 for (i in Iter.range(0, 2)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
-buffer3.add(2);
-buffer3.add(1);
-buffer3.add(0);
+B.add(buffer3, 2);
+B.add(buffer3, 1);
+B.add(buffer3, 0);
 
 run(
   suite(
@@ -3020,60 +3020,60 @@ run(
       test(
         "normal prefix",
         B.isPrefixOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "identical buffers",
         B.isPrefixOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "one empty buffer",
-        B.isPrefixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isPrefixOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not prefix",
         B.isPrefixOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not prefix from length",
         B.isPrefixOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not prefix of empty",
-        B.isPrefixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isPrefixOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty prefix of empty",
-        B.isPrefixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(true))
-      )
-    ]
+        B.isPrefixOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(true)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 for (i in Iter.range(0, 2)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
-buffer3.add(2);
-buffer3.add(1);
-buffer3.add(0);
+B.add(buffer3, 2);
+B.add(buffer3, 1);
+B.add(buffer3, 0);
 
 run(
   suite(
@@ -3082,47 +3082,47 @@ run(
       test(
         "normal prefix",
         B.isStrictPrefixOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "identical buffers",
         B.isStrictPrefixOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "one empty buffer",
-        B.isStrictPrefixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isStrictPrefixOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not prefix",
         B.isStrictPrefixOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not prefix from length",
         B.isStrictPrefixOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not prefix of empty",
-        B.isStrictPrefixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isStrictPrefixOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty prefix of empty",
-        B.isStrictPrefixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        B.isStrictPrefixOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer := B.subBuffer<Nat>(buffer, 1, 3);
@@ -3133,23 +3133,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [1, 2, 3]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [1, 2, 3])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3159,44 +3159,44 @@ run(
       test(
         "prefix",
         B.prefix(buffer, 3),
-        M.equals({ { item = B.subBuffer(buffer, 0, 3) } and NatBufferTestable })
+        M.equals({ { item = B.subBuffer(buffer, 0, 3) } and NatBufferTestable }),
       ),
       test(
         "suffix",
         B.suffix(buffer, 3),
-        M.equals({ { item = B.subBuffer(buffer, 2, 3) } and NatBufferTestable })
+        M.equals({ { item = B.subBuffer(buffer, 2, 3) } and NatBufferTestable }),
       ),
       test(
         "empty",
         B.toArray(B.subBuffer(buffer, 2, 0)),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "trivial",
-        B.subBuffer(buffer, 0, buffer.size()),
-        M.equals({ { item = buffer } and NatBufferTestable })
-      )
-    ]
+        B.subBuffer(buffer, 0, B.size(buffer)),
+        M.equals({ { item = buffer } and NatBufferTestable }),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 for (i in Iter.range(0, 2)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
 for (i in Iter.range(1, 3)) {
-  buffer3.add(i)
+  B.add(buffer3, i);
 };
 
 run(
@@ -3206,70 +3206,70 @@ run(
       test(
         "normal subBuffer",
         B.isSubBufferOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "prefix",
         B.isSubBufferOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "identical buffers",
         B.isSubBufferOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "one empty buffer",
-        B.isSubBufferOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isSubBufferOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not subBuffer",
         B.isSubBufferOf<Nat>(buffer3, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not subBuffer from length",
         B.isSubBufferOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not subBuffer of empty",
-        B.isSubBufferOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isSubBufferOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty subBuffer of empty",
-        B.isSubBufferOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(true))
-      )
-    ]
+        B.isSubBufferOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(true)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 
 for (i in Iter.range(0, 2)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
 for (i in Iter.range(1, 3)) {
-  buffer3.add(i)
+  B.add(buffer3, i);
 };
 
-buffer4 := B.Buffer<Nat>(4);
+buffer4 := B.initPresized<Nat>(4);
 
 for (i in Iter.range(3, 4)) {
-  buffer4.add(i)
+  B.add(buffer4, i);
 };
 
 run(
@@ -3279,57 +3279,57 @@ run(
       test(
         "normal strict subBuffer",
         B.isStrictSubBufferOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "prefix",
         B.isStrictSubBufferOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "suffix",
         B.isStrictSubBufferOf<Nat>(buffer4, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "identical buffers",
         B.isStrictSubBufferOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "one empty buffer",
-        B.isStrictSubBufferOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isStrictSubBufferOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not subBuffer",
         B.isStrictSubBufferOf<Nat>(buffer3, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not subBuffer from length",
         B.isStrictSubBufferOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not subBuffer of empty",
-        B.isStrictSubBufferOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isStrictSubBufferOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty not strict subBuffer of empty",
-        B.isStrictSubBufferOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        B.isStrictSubBufferOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 buffer := B.suffix<Nat>(buffer, 3);
@@ -3340,23 +3340,23 @@ run(
     [
       test(
         "capacity",
-        buffer.capacity(),
-        M.equals(T.nat(5))
+        B.capacity(buffer),
+        M.equals(T.nat(5)),
       ),
       test(
         "elements",
         B.toArray(buffer),
-        M.equals(T.array(T.natTestable, [2, 3, 4]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3366,34 +3366,34 @@ run(
       test(
         "empty",
         B.toArray(B.prefix(buffer, 0)),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "trivial",
-        B.prefix(buffer, buffer.size()),
-        M.equals({ { item = buffer } and NatBufferTestable })
-      )
-    ]
+        B.prefix(buffer, B.size(buffer)),
+        M.equals({ { item = buffer } and NatBufferTestable }),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 for (i in Iter.range(3, 4)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
-buffer3.add(2);
-buffer3.add(1);
-buffer3.add(0);
+B.add(buffer3, 2);
+B.add(buffer3, 1);
+B.add(buffer3, 0);
 
 run(
   suite(
@@ -3402,59 +3402,59 @@ run(
       test(
         "normal suffix",
         B.isSuffixOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "identical buffers",
         B.isSuffixOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "one empty buffer",
-        B.isSuffixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isSuffixOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not suffix",
         B.isSuffixOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not suffix from length",
         B.isSuffixOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not suffix of empty",
-        B.isSuffixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isSuffixOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty suffix of empty",
-        B.isSuffixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(true))
-      )
-    ]
+        B.isSuffixOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(true)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
-buffer2.clear();
+B.clear(buffer2);
 for (i in Iter.range(3, 4)) {
-  buffer2.add(i)
+  B.add(buffer2, i);
 };
 
-buffer3.clear();
+B.clear(buffer3);
 
-buffer3.add(2);
-buffer3.add(1);
-buffer3.add(0);
+B.add(buffer3, 2);
+B.add(buffer3, 1);
+B.add(buffer3, 0);
 
 run(
   suite(
@@ -3463,47 +3463,47 @@ run(
       test(
         "normal suffix",
         B.isStrictSuffixOf<Nat>(buffer2, buffer, Nat.equal),
-        M.equals(T.bool(true))
+        M.equals(T.bool(true)),
       ),
       test(
         "identical buffers",
         B.isStrictSuffixOf<Nat>(buffer, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "one empty buffer",
-        B.isStrictSuffixOf<Nat>(B.Buffer<Nat>(3), buffer, Nat.equal),
-        M.equals(T.bool(true))
+        B.isStrictSuffixOf<Nat>(B.initPresized<Nat>(3), buffer, Nat.equal),
+        M.equals(T.bool(true)),
       ),
       test(
         "not suffix",
         B.isStrictSuffixOf<Nat>(buffer3, buffer, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not suffix from length",
         B.isStrictSuffixOf<Nat>(buffer, buffer2, Nat.equal),
-        M.equals(T.bool(false))
+        M.equals(T.bool(false)),
       ),
       test(
         "not suffix of empty",
-        B.isStrictSuffixOf<Nat>(buffer, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
+        B.isStrictSuffixOf<Nat>(buffer, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
       ),
       test(
         "empty suffix of empty",
-        B.isStrictSuffixOf<Nat>(B.Buffer<Nat>(4), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.bool(false))
-      )
-    ]
+        B.isStrictSuffixOf<Nat>(B.initPresized<Nat>(4), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.bool(false)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3513,22 +3513,22 @@ run(
       test(
         "normal case",
         B.toArray(B.takeWhile<Nat>(buffer, func x = x < 3)),
-        M.equals(T.array(T.natTestable, [0, 1, 2]))
+        M.equals(T.array(T.natTestable, [0, 1, 2])),
       ),
       test(
         "empty",
-        B.toArray(B.takeWhile<Nat>(B.Buffer<Nat>(3), func x = x < 3)),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
-      )
-    ]
+        B.toArray(B.takeWhile<Nat>(B.initPresized<Nat>(3), func x = x < 3)),
+        M.equals(T.array(T.natTestable, [] : [Nat])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 4)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3538,32 +3538,32 @@ run(
       test(
         "normal case",
         B.toArray(B.dropWhile<Nat>(buffer, func x = x < 3)),
-        M.equals(T.array(T.natTestable, [3, 4]))
+        M.equals(T.array(T.natTestable, [3, 4])),
       ),
       test(
         "empty",
-        B.toArray(B.dropWhile<Nat>(B.Buffer<Nat>(3), func x = x < 3)),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        B.toArray(B.dropWhile<Nat>(B.initPresized<Nat>(3), func x = x < 3)),
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "drop all",
         B.toArray(B.dropWhile<Nat>(buffer, func _ = true)),
-        M.equals(T.array(T.natTestable, [] : [Nat]))
+        M.equals(T.array(T.natTestable, [] : [Nat])),
       ),
       test(
         "drop none",
         B.toArray(B.dropWhile<Nat>(buffer, func _ = false)),
-        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4]))
-      )
-    ]
+        M.equals(T.array(T.natTestable, [0, 1, 2, 3, 4])),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(1, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3573,37 +3573,37 @@ run(
       test(
         "find in middle",
         B.binarySearch<Nat>(2, buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, ?1))
+        M.equals(T.optional(T.natTestable, ?1)),
       ),
       test(
         "find first",
         B.binarySearch<Nat>(1, buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, ?0))
+        M.equals(T.optional(T.natTestable, ?0)),
       ),
       test(
         "find last",
         B.binarySearch<Nat>(6, buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, ?5))
+        M.equals(T.optional(T.natTestable, ?5)),
       ),
       test(
         "not found to the right",
         B.binarySearch<Nat>(10, buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "not found to the left",
         B.binarySearch<Nat>(0, buffer, Nat.compare),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      )
-    ]
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
 for (i in Iter.range(0, 6)) {
-  buffer.add(i)
+  B.add(buffer, i);
 };
 
 run(
@@ -3613,44 +3613,44 @@ run(
       test(
         "find in middle",
         B.indexOf<Nat>(2, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?2))
+        M.equals(T.optional(T.natTestable, ?2)),
       ),
       test(
         "find first",
         B.indexOf<Nat>(0, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?0))
+        M.equals(T.optional(T.natTestable, ?0)),
       ),
       test(
         "find last",
         B.indexOf<Nat>(6, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?6))
+        M.equals(T.optional(T.natTestable, ?6)),
       ),
       test(
         "not found",
         B.indexOf<Nat>(10, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "empty",
-        B.indexOf<Nat>(100, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      )
-    ]
+        B.indexOf<Nat>(100, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.add(2); // 0
-buffer.add(2); // 1
-buffer.add(1); // 2
-buffer.add(10); // 3
-buffer.add(1); // 4
-buffer.add(0); // 5
-buffer.add(10); // 6
-buffer.add(3); // 7
-buffer.add(0); // 8
+B.add(buffer, 2); // 0
+B.add(buffer, 2); // 1
+B.add(buffer, 1); // 2
+B.add(buffer, 10); // 3
+B.add(buffer, 1); // 4
+B.add(buffer, 0); // 5
+B.add(buffer, 10); // 6
+B.add(buffer, 3); // 7
+B.add(buffer, 0); // 8
 
 run(
   suite(
@@ -3659,43 +3659,43 @@ run(
       test(
         "find in middle",
         B.lastIndexOf<Nat>(10, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?6))
+        M.equals(T.optional(T.natTestable, ?6)),
       ),
       test(
         "find only",
         B.lastIndexOf<Nat>(3, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?7))
+        M.equals(T.optional(T.natTestable, ?7)),
       ),
       test(
         "find last",
         B.lastIndexOf<Nat>(0, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?8))
+        M.equals(T.optional(T.natTestable, ?8)),
       ),
       test(
         "not found",
         B.lastIndexOf<Nat>(100, buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "empty",
-        B.lastIndexOf<Nat>(100, B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      )
-    ]
+        B.lastIndexOf<Nat>(100, B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
+      ),
+    ],
   )
 );
 
 /* --------------------------------------- */
-buffer.clear();
+B.clear(buffer);
 
-buffer.add(2); // 0
-buffer.add(2); // 1
-buffer.add(1); // 2
-buffer.add(10); // 3
-buffer.add(1); // 4
-buffer.add(10); // 5
-buffer.add(3); // 6
-buffer.add(0); // 7
+B.add(buffer, 2); // 0
+B.add(buffer, 2); // 1
+B.add(buffer, 1); // 2
+B.add(buffer, 10); // 3
+B.add(buffer, 1); // 4
+B.add(buffer, 10); // 5
+B.add(buffer, 3); // 6
+B.add(buffer, 0); // 7
 
 run(
   suite(
@@ -3704,38 +3704,38 @@ run(
       test(
         "find in middle",
         B.indexOfBuffer<Nat>(B.fromArray<Nat>([1, 10, 1]), buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?2))
+        M.equals(T.optional(T.natTestable, ?2)),
       ),
       test(
         "find first",
         B.indexOfBuffer<Nat>(B.fromArray<Nat>([2, 2, 1, 10]), buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?0))
+        M.equals(T.optional(T.natTestable, ?0)),
       ),
       test(
         "find last",
         B.indexOfBuffer<Nat>(B.fromArray<Nat>([0]), buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, ?7))
+        M.equals(T.optional(T.natTestable, ?7)),
       ),
       test(
         "not found",
         B.indexOfBuffer<Nat>(B.fromArray<Nat>([99, 100, 1]), buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "search for empty buffer",
         B.indexOfBuffer<Nat>(B.fromArray<Nat>([]), buffer, Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "search through empty buffer",
-        B.indexOfBuffer<Nat>(B.fromArray<Nat>([1, 2, 3]), B.Buffer<Nat>(2), Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
+        B.indexOfBuffer<Nat>(B.fromArray<Nat>([1, 2, 3]), B.initPresized<Nat>(2), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
       ),
       test(
         "search for empty in empty",
-        B.indexOfBuffer<Nat>(B.Buffer<Nat>(2), B.Buffer<Nat>(3), Nat.equal),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      )
-    ]
+        B.indexOfBuffer<Nat>(B.initPresized<Nat>(2), B.initPresized<Nat>(3), Nat.equal),
+        M.equals(T.optional(T.natTestable, null : ?Nat)),
+      ),
+    ],
   )
-)
+);

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,5 @@
+TEST_FILE?=StableBufferTest.mo
+
 default:
-	$(shell vessel bin)/moc $(shell vessel sources) -wasi-system-api -o Test.wasm StableBufferTest.mo && wasmtime Test.wasm
+	$(shell vessel bin)/moc $(shell vessel sources) -wasi-system-api -o Test.wasm ${TEST_FILE} && wasmtime Test.wasm
 	rm -f Test.wasm

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,1 +1,1 @@
-{ dependencies = [ "base" ], compiler = Some "0.6.21" }
+{ dependencies = [ "base" ], compiler = Some "0.9.1" }


### PR DESCRIPTION
This PR updates the Buffer.test.mo from #16 to test the StableBuffer instead.

Use `cd test && make TEST_FILE=Buffer.test.mo` to run the tests.

A separate PR will be created to rename the Test file and use it as the default test in the Makefile.